### PR TITLE
fix: popular content and referrer views metrics

### DIFF
--- a/lib/scraper/traffic-top-paths.js
+++ b/lib/scraper/traffic-top-paths.js
@@ -23,14 +23,13 @@ class TrafficTopPaths {
   }
 
   scrapeRepositories (repositories) {
+    this.metrics.githubRepoPopularContentViewsGauge.reset()
+    this.metrics.githubRepoPopularContentViewsUniqueGauge.reset()
     repositories.forEach((repository) => {
       const [owner, repo] = repository.split('/')
       ghRestApi.repos
         .getTopPaths({ owner, repo })
         .then((response) => {
-          this.metrics.githubRepoPopularContentViewsGauge.reset()
-          this.metrics.githubRepoPopularContentViewsUniqueGauge.reset()
-
           response.data.forEach((path) => {
             this.metrics.githubRepoPopularContentViewsGauge.set(
               { owner, repository, path: path.path },

--- a/lib/scraper/traffic-top-referrers.js
+++ b/lib/scraper/traffic-top-referrers.js
@@ -23,14 +23,13 @@ class TrafficTopReferrers {
   }
 
   scrapeRepositories (repositories) {
+    this.metrics.githubRepoReferrerViewsGauge.reset()
+    this.metrics.githubRepoReferrerViewsUniqueGauge.reset()
     repositories.forEach((repository) => {
       const [owner, repo] = repository.split('/')
       ghRestApi.repos
         .getTopReferrers({ owner, repo })
         .then((response) => {
-          this.metrics.githubRepoReferrerViewsGauge.reset()
-          this.metrics.githubRepoReferrerViewsUniqueGauge.reset()
-
           response.data.forEach((referrer) => {
             this.metrics.githubRepoReferrerViewsGauge.set(
               { owner, repository, referrer: referrer.referrer },


### PR DESCRIPTION
All the gauges for these metrics are reset for every repository, which results in only the metrics for the last repository being available. This PR fixes this by resetting the gauges before iterating through the repositories.